### PR TITLE
fix: remove "Herr" prefix from founder name in FounderCard

### DIFF
--- a/src/components/FounderCard.tsx
+++ b/src/components/FounderCard.tsx
@@ -23,7 +23,7 @@ export default function FounderCard() {
           </p>
 
           <div className="mt-6 flex flex-col items-center md:items-end gap-1">
-            <div className="text-base font-semibold">Herr Orif Akhmadaliev</div>
+            <div className="text-base font-semibold">Orif Akhmadaliev</div>
             <div className="text-sm text-muted-foreground">{t("founder_role")}</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Removed hard-coded "Herr" prefix from founder name in `FounderCard.tsx` for consistency with i18n dict (which already uses "Orif Akhmadaliev")
- Bundles 2 prior unmerged commits on this branch (new pages/client-side components + segment refactor)

## Deploy
✅ Deployed to Vercel → https://www.consultinguz.de
   (preview: https://consultinguz-ixxqc9e2e-akhrorsolievs-projects.vercel.app)

## Test plan
- [ ] Visit the deploy URL and confirm founder name shows as "Orif Akhmadaliev" (no "Herr")
- [ ] Verify both DE and UZ render correctly via the navbar toggle
- [ ] Smoke-test new routes from prior commits

---
🤖 Auto-deployed with `/deploy`