### PR TITLE
fix: show owner and company name on datenschutz responsible entity

### DIFF
--- a/src/app/datenschutz/DatenschutzClient.tsx
+++ b/src/app/datenschutz/DatenschutzClient.tsx
@@ -18,7 +18,8 @@ import {
 import { Section } from "@/components/ui/section";
 import { useI18n } from "@/components/providers/translation-provider";
 
-const COMPANY_NAME = "consultinguz.uz";
+const COMPANY_OWNER = "Orif Akhmadaliev";
+const COMPANY_NAME = "ConsultingUZ";
 const COMPANY_ADDRESS = "Alemannenweg 6, 72488 Sigmaringen, Deutschland";
 const COMPANY_EMAIL = "orif.ahmadaliyev@consultinguz.de";
 const COMPANY_PHONE = "+49 176 238 97 113";
@@ -115,7 +116,10 @@ export default function DatenschutzClient() {
               <p className="text-sm text-muted-foreground mb-5">{c.responsible_intro}</p>
               <ul className="space-y-4">
                 <InfoRow icon={Building2} label={c.label_company}>
-                  <span>{COMPANY_NAME}</span>
+                  <span className="flex flex-col">
+                    <span>{COMPANY_OWNER}</span>
+                    <span>{COMPANY_NAME}</span>
+                  </span>
                 </InfoRow>
                 <InfoRow icon={MapPin} label={c.label_address}>
                   <span>{COMPANY_ADDRESS}</span>


### PR DESCRIPTION
## Summary
- Updated `Verantwortliche Stelle` on `/datenschutz` to show owner ("Orif Akhmadaliev") and company ("ConsultingUZ") instead of the prior `consultinguz.uz` value

## Deploy
✅ Deployed to Vercel → https://www.consultinguz.de

## Test plan
- [ ] Visit /datenschutz and confirm UNTERNEHMEN shows two lines: "Orif Akhmadaliev" / "ConsultingUZ"
- [ ] Verify both DE and UZ render correctly via the navbar toggle

---
🤖 Auto-deployed with \`/deploy\`